### PR TITLE
Interpolate in time and rotate

### DIFF
--- a/blender-addon/mb_scene.py
+++ b/blender-addon/mb_scene.py
@@ -29,6 +29,7 @@
 import bpy
 import bidict
 import random
+import math
 
 from . import mb_utils
 
@@ -52,9 +53,27 @@ class ManySpheres:
         bpy.ops.object.empty_add(type='PLAIN_AXES', align='WORLD',
                                  location=(0, 0, 0), scale=(1, 1, 1))
         parent_object = bpy.context.active_object
+        ManySpheres.adapt_between_mastodon_and_blender_coordinates(parent_object)
         bpy.ops.collection.objects_remove_all()
         collection.objects.link(parent_object)
         return parent_object
+
+    @staticmethod
+    def adapt_between_mastodon_and_blender_coordinates(parent_object):
+        # Mastodon and Blender orient the coordinate system differently.
+        #
+        #            | up   | back | right
+        #  --------- | ---- | ---- | ----
+        #  Blender   | Z    | Y    | X
+        #  Mastodon  | -Y   | Z    | X
+        #
+        # There are two ways to adapt between the two coordinate systems:
+        # 1. Rotate the parent object by 180 degrees around the x-axis.
+        #  - Y axis becomes -Y axis, Z axis becomes -Z axis.
+        #  - Front view in Mastodon is top view in Blender.
+        # 2. Rotate the parent object by -90 degrees around the x-axis.
+        #  - Correctly maps front, back and up view but flips the Y and Z axis.
+        parent_object.rotation_euler = (math.radians(180), 0, 0)
 
     @staticmethod
     def init_sphere_material():

--- a/mastodon-plugin/src/main/java/org/mastodon/blender/ViewServiceClient.java
+++ b/mastodon-plugin/src/main/java/org/mastodon/blender/ViewServiceClient.java
@@ -56,6 +56,14 @@ import java.util.function.ToIntFunction;
 
 public class ViewServiceClient
 {
+	/**
+	 * Factor for scaling between Mastodon timepoints and Blender frames.
+	 * One Mastodon timepoint is mapped to the given number of Blender frames.
+	 * <p>
+	 * Mapping a timepoint to multiple frames in Blender has the advantage
+	 * that the Blender automatically interpolates between the timepoints.
+	 **/
+	private static final int TIME_SCALING_FACTOR = 10;
 
 	public static final String URL = "localhost:";
 
@@ -64,8 +72,6 @@ public class ViewServiceClient
 	private final ViewServiceGrpc.ViewServiceStub nonBlockingStub;
 
 	private final Listener listener;
-
-	private int timeScalingFactor = 10;
 
 	public static void waitForConnection( int port )
 	{
@@ -127,7 +133,7 @@ public class ViewServiceClient
 
 	public int receiveTimepoint()
 	{
-		return Math.round( (float) blockingStub.getTimePoint( Empty.newBuilder().build() ).getTimePoint() / timeScalingFactor );
+		return Math.round( ( float ) blockingStub.getTimePoint( Empty.newBuilder().build() ).getTimePoint() / TIME_SCALING_FACTOR );
 	}
 
 	public int receiveActiveSpotId()
@@ -161,8 +167,8 @@ public class ViewServiceClient
 	{
 		//System.out.println("Mastodon -> Blender: set time point to " + timePoint);
 		blockingStub.setTimePoint( SetTimePointRequest.newBuilder()
-				.setTimepoint(timePoint * timeScalingFactor)
-				.build());
+				.setTimepoint( timePoint * TIME_SCALING_FACTOR )
+				.build() );
 	}
 
 	public void sendCoordinates( ModelGraph graph )
@@ -230,7 +236,7 @@ public class ViewServiceClient
 		request.addCoordinates( point.getFloatPosition( 0 ) );
 		request.addCoordinates( point.getFloatPosition( 1 ) );
 		request.addCoordinates( point.getFloatPosition( 2 ) );
-		request.addTimepoints( spot.getTimepoint() * timeScalingFactor );
+		request.addTimepoints( spot.getTimepoint() * TIME_SCALING_FACTOR );
 	}
 
 	// callback


### PR DESCRIPTION
Fixes #8 

Scale time by a factor of 10.
- Each timepoint in Mastodon is translated to ten frames in Blender. 
- Blender key-frames approach automatically generates an interpolation between timepoints.

In Blender rotate visualization by 180 degree around x-axis. This means that the embryo in Blender top-view, is oriented as in BDV XY-view.
(There an other option to rotate by -90 degree, which means that the front-view in Blender is oriented the same as in BDV. Discussion is needed what is best for out users)